### PR TITLE
[codex] add isolated pytest MCP suite

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: Pytest MCP Suite
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run pytest suite
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ data/
 
 # Python
 __pycache__/
+.pytest_cache/
 *.pyc
 *.pyo
 .venv/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests/pytest_suite
+addopts = -ra

--- a/tests/pytest_suite/conftest.py
+++ b/tests/pytest_suite/conftest.py
@@ -1,0 +1,287 @@
+"""Pytest fixtures for the MCP regression suite."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKER_DIR = REPO_ROOT / "docker"
+SQLITE_PATH = "/data/.rlm/memory/memory_bridge_v2.db"
+DEFAULT_MODEL = "paraphrase-multilingual-MiniLM-L12-v2"
+
+
+class RLMClient:
+    """Tiny MCP client for the streamable-http transport."""
+
+    def __init__(self, base_url: str, timeout: int = 30):
+        self.base_url = base_url
+        self.timeout = timeout
+        self.session_id: str | None = None
+        self._call_id = 1
+        self._created_ids: list[str] = []
+
+    def _post(self, payload: dict) -> str:
+        body = json.dumps(payload).encode("utf-8")
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        req = urllib.request.Request(
+            self.base_url,
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                sid = resp.headers.get("Mcp-Session-Id")
+                if sid:
+                    self.session_id = sid
+                return resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            return exc.read().decode("utf-8")
+
+    @staticmethod
+    def _parse_response(raw: str) -> dict | None:
+        for line in raw.splitlines():
+            if line.startswith("data:"):
+                data = line[5:].strip()
+                if data and data != "[DONE]":
+                    return json.loads(data)
+        if raw.strip():
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    def initialize(self) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._call_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest-rlm", "version": "1.0"},
+            },
+        }
+        self._call_id += 1
+        self._post(payload)
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def call(self, tool_name: str, **kwargs) -> dict:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._call_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": kwargs},
+        }
+        self._call_id += 1
+        raw = self._post(payload)
+        msg = self._parse_response(raw)
+        if msg and "result" in msg:
+            for item in msg["result"].get("content", []):
+                if item.get("type") == "text":
+                    try:
+                        return json.loads(item["text"])
+                    except json.JSONDecodeError:
+                        return {"text": item["text"]}
+            structured = msg["result"].get("structuredContent")
+            if isinstance(structured, dict):
+                return structured.get("result", structured)
+        return msg or {}
+
+
+def _run(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_server(base_url: str, timeout: int = 180) -> None:
+    client = RLMClient(base_url=base_url, timeout=10)
+    deadline = time.time() + timeout
+    last_error = ""
+    while time.time() < deadline:
+        try:
+            client.initialize()
+            return
+        except Exception as exc:  # pragma: no cover - best effort retry loop
+            last_error = str(exc)
+        time.sleep(2)
+    raise RuntimeError(f"Timed out waiting for MCP server: {last_error}")
+
+
+@pytest.fixture(scope="session")
+def rlm_env():
+    """Build and run an isolated Docker-backed RLM instance for the suite."""
+
+    external_url = os.environ.get("RLM_TEST_URL")
+    if external_url:
+        yield {
+            "base_url": external_url,
+            "container_name": os.environ.get("RLM_DOCKER_CONTAINER", ""),
+            "image_name": os.environ.get("RLM_TEST_IMAGE", ""),
+            "sqlite_path": os.environ.get("RLM_SQLITE_PATH", SQLITE_PATH),
+            "expected_model": os.environ.get("RLM_EXPECTED_MODEL", DEFAULT_MODEL),
+        }
+        return
+
+    probe = _run(["docker", "version"], check=False)
+    if probe.returncode != 0:
+        pytest.skip(f"Docker is unavailable: {probe.stderr.strip()}")
+
+    suffix = uuid.uuid4().hex[:8]
+    image_name = os.environ.get("RLM_TEST_IMAGE", f"rlm-workflow-pytest:{suffix}")
+    container_name = f"rlm-pytest-{suffix}"
+    port = int(os.environ.get("RLM_TEST_PORT", _find_free_port()))
+
+    if "RLM_TEST_IMAGE" not in os.environ:
+        build = _run(["docker", "build", "-t", image_name, str(DOCKER_DIR)], check=False)
+        if build.returncode != 0:
+            pytest.skip(f"Failed to build Docker image:\n{build.stderr.strip()}")
+
+    run_command = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        container_name,
+        "-p",
+        f"{port}:8200",
+        "-e",
+        "RLM_DATA_DIR=/data",
+        "-e",
+        "RLM_HOST=0.0.0.0",
+        "-e",
+        "RLM_PORT=8200",
+        "-e",
+        "RLM_TRANSPORT=streamable-http",
+        "-e",
+        f"RLM_EMBEDDING_MODEL={DEFAULT_MODEL}",
+        "-e",
+        "RLM_EMBEDDING_PROVIDER=fastembed",
+        image_name,
+    ]
+    started = _run(run_command, check=False)
+    if started.returncode != 0:
+        pytest.skip(f"Failed to start test container:\n{started.stderr.strip()}")
+
+    base_url = f"http://127.0.0.1:{port}/mcp"
+    start_timeout = int(os.environ.get("RLM_TEST_START_TIMEOUT", "600"))
+    try:
+        _wait_for_server(base_url, timeout=start_timeout)
+    except Exception as exc:  # pragma: no cover - setup failure path
+        logs = _run(["docker", "logs", container_name], check=False)
+        _run(["docker", "rm", "-f", container_name], check=False)
+        pytest.fail(f"Failed to start MCP server: {exc}\n{logs.stdout}\n{logs.stderr}")
+
+    yield {
+        "base_url": base_url,
+        "container_name": container_name,
+        "image_name": image_name,
+        "sqlite_path": SQLITE_PATH,
+        "expected_model": DEFAULT_MODEL,
+    }
+
+    _run(["docker", "rm", "-f", container_name], check=False)
+    if "RLM_TEST_IMAGE" not in os.environ:
+        _run(["docker", "rmi", image_name], check=False)
+
+
+def docker_logs(container: str) -> str:
+    result = _run(["docker", "logs", container], check=False)
+    if result.returncode != 0:
+        pytest.fail(f"docker logs failed: {result.stderr.strip()}")
+    return result.stdout + result.stderr
+
+
+def query_rlm_db(container: str, sql: str, sqlite_path: str = SQLITE_PATH) -> str:
+    script = (
+        "import json, sqlite3; "
+        f"conn = sqlite3.connect({sqlite_path!r}); "
+        f"print(json.dumps(conn.execute({sql!r}).fetchall(), ensure_ascii=False))"
+    )
+    result = _run(
+        ["docker", "exec", container, "python3", "-c", script],
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"query_rlm_db failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+@pytest.fixture(scope="session")
+def client(rlm_env):
+    c = RLMClient(base_url=rlm_env["base_url"])
+    c.initialize()
+    return c
+
+
+@pytest.fixture
+def rlm(client):
+    client._created_ids = []
+    client.call("rlm_start_session", restore=False)
+    yield client
+    for fact_id in list(client._created_ids):
+        try:
+            client.call("rlm_delete_fact", fact_id=fact_id)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def causal_seed(rlm):
+    marker = f"PYTEST_CAUSAL_{uuid.uuid4().hex}"
+    result = rlm.call(
+        "rlm_record_causal_decision",
+        decision=f"Test decision {marker}",
+        reasons=[f"Test reasoning {marker}"],
+        alternatives=["none"],
+        consequences=[f"Test only {marker}"],
+    )
+    assert result.get("decision_id") or result.get("status") == "success"
+    return marker
+
+
+@pytest.fixture
+def fact_seed(rlm):
+    marker = f"PYTEST_SEED_{uuid.uuid4().hex[:8]}"
+    for content in [
+        f"PENDING tasks next session: {marker}",
+        f"Unfinished tasks for the next session: {marker}",
+    ]:
+        result = rlm.call(
+            "rlm_add_hierarchical_fact",
+            content=content,
+            domain="workflow",
+            level=1,
+        )
+        if result.get("fact_id"):
+            rlm._created_ids.append(result["fact_id"])
+    return marker

--- a/tests/pytest_suite/test_scenarios.py
+++ b/tests/pytest_suite/test_scenarios.py
@@ -1,0 +1,126 @@
+"""Scenario tests for session behavior and data hygiene."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def test_session_continuity(client):
+    marker = f"CONTINUITY_{uuid.uuid4().hex[:8]}"
+    client._created_ids = []
+    client.call("rlm_start_session", restore=False)
+
+    created = client.call(
+        "rlm_add_hierarchical_fact",
+        content=f"Session continuity test: {marker}",
+        domain="workflow",
+        level=1,
+    )
+    fact_id = created["fact_id"]
+
+    client.call("rlm_start_session", restore=True)
+    result = client.call(
+        "rlm_search_facts",
+        query=marker,
+        keyword_weight=0.9,
+        recency_weight=0.0,
+        top_k=5,
+    )
+    found_ids = [item["fact_id"] for item in result.get("results", [])]
+
+    client.call("rlm_delete_fact", fact_id=fact_id)
+    assert fact_id in found_ids
+
+
+def test_semantic_relevance(rlm, fact_seed):
+    result = rlm.call(
+        "rlm_search_facts",
+        query=f"unfinished tasks for the next session {fact_seed}",
+        semantic_weight=0.5,
+        keyword_weight=0.4,
+        recency_weight=0.1,
+        top_k=10,
+    )
+    assert result.get("results"), "Expected PENDING-style facts in semantic search"
+    assert any(fact_seed in item.get("content", "") for item in result["results"])
+
+
+def test_domain_isolation(rlm):
+    marker = f"DOMAIN_ISO_{uuid.uuid4().hex[:8]}"
+
+    workflow_fact = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content=f"workflow-only {marker}",
+        domain="workflow",
+        level=1,
+    )
+    vertical_fact = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content=f"vertical-only {marker}",
+        domain="vertical",
+        level=1,
+    )
+    rlm._created_ids.extend([workflow_fact["fact_id"], vertical_fact["fact_id"]])
+
+    def fact_ids(domain: str) -> set[str]:
+        facts = rlm.call("rlm_get_facts_by_domain", domain=domain).get("facts", [])
+        return {fact.get("id") or fact.get("fact_id") for fact in facts}
+
+    workflow_ids = fact_ids("workflow")
+    vertical_ids = fact_ids("vertical")
+
+    assert workflow_fact["fact_id"] in workflow_ids
+    assert workflow_fact["fact_id"] not in vertical_ids
+    assert vertical_fact["fact_id"] in vertical_ids
+    assert vertical_fact["fact_id"] not in workflow_ids
+
+
+def test_repeated_runs_stable(rlm, fact_seed):
+    params = {
+        "query": f"PENDING tasks {fact_seed}",
+        "keyword_weight": 0.7,
+        "semantic_weight": 0.2,
+        "recency_weight": 0.1,
+        "top_k": 5,
+    }
+    runs = [
+        [item["fact_id"] for item in rlm.call("rlm_search_facts", **params).get("results", [])]
+        for _ in range(3)
+    ]
+    assert runs[0] == runs[1] == runs[2]
+
+
+def test_add_delete_cycle_restores_total_facts(rlm):
+    baseline = rlm.call("rlm_get_hierarchy_stats")
+    baseline_total = baseline["memory_store"]["total_facts"]
+
+    created_ids = []
+    for index in range(5):
+        created = rlm.call(
+            "rlm_add_hierarchical_fact",
+            content=f"Cycle test fact {index} ADDDELETE_pytest",
+            domain="workflow",
+            level=1,
+        )
+        created_ids.append(created["fact_id"])
+
+    for fact_id in created_ids:
+        rlm.call("rlm_delete_fact", fact_id=fact_id)
+
+    after = rlm.call("rlm_get_hierarchy_stats")
+    assert after["memory_store"]["total_facts"] == baseline_total
+
+
+def test_deleted_fact_does_not_become_stale(rlm):
+    created = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content="Stale test STALE_pytest",
+        domain="workflow",
+        level=3,
+    )
+    fact_id = created["fact_id"]
+    rlm.call("rlm_delete_fact", fact_id=fact_id)
+
+    stale = rlm.call("rlm_get_stale_facts")
+    stale_ids = [fact.get("fact_id") or fact.get("id") for fact in stale.get("stale_facts", [])]
+    assert fact_id not in stale_ids

--- a/tests/pytest_suite/test_tools.py
+++ b/tests/pytest_suite/test_tools.py
@@ -1,0 +1,187 @@
+"""MCP tool-level tests for the isolated pytest suite."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import uuid
+
+
+def test_start_session_restore_false(client):
+    result = client.call("rlm_start_session", restore=False)
+    assert result.get("restored") is False
+
+
+def test_start_session_restore_true(client):
+    marker = f"RESTORE_{uuid.uuid4().hex[:8]}"
+    client.call("rlm_start_session", restore=False)
+    created = client.call(
+        "rlm_add_hierarchical_fact",
+        content=f"Restore checkpoint {marker}",
+        domain="workflow",
+        level=1,
+    )
+    fact_id = created["fact_id"]
+    client.call("rlm_sync_state")
+
+    restored_client = client.__class__(base_url=client.base_url)
+    restored_client.initialize()
+    result = restored_client.call("rlm_start_session", restore=True)
+    assert result.get("restored") is True
+
+    search = restored_client.call(
+        "rlm_search_facts",
+        query=marker,
+        keyword_weight=0.9,
+        recency_weight=0.0,
+        top_k=5,
+    )
+    found_ids = [item["fact_id"] for item in search.get("results", [])]
+    assert fact_id in found_ids
+    restored_client.call("rlm_delete_fact", fact_id=fact_id)
+
+
+def test_add_fact_returns_fact_id(rlm):
+    result = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content="Test fact for pytest suite",
+        domain="workflow",
+        level=1,
+    )
+    assert result.get("status") == "success"
+    assert result.get("fact_id")
+    rlm._created_ids.append(result["fact_id"])
+
+
+def test_search_existing_fact(rlm, fact_seed):
+    result = rlm.call(
+        "rlm_search_facts",
+        query=fact_seed,
+        keyword_weight=0.9,
+        semantic_weight=0.1,
+        recency_weight=0.0,
+        top_k=5,
+    )
+    matches = result.get("results", [])
+    assert matches, "Expected results for the seeded marker"
+    assert any(fact_seed in item.get("content", "") for item in matches)
+
+
+def test_search_nonexistent_returns_empty(rlm):
+    result = rlm.call(
+        "rlm_search_facts",
+        query="xyzzy12345nonsense_pytest_marker_impossible",
+        keyword_weight=0.9,
+        semantic_weight=0.1,
+        recency_weight=0.0,
+        top_k=5,
+    )
+    assert result.get("results") == []
+
+
+def test_delete_fact_removes_search_hit(rlm):
+    marker = f"DELETE_ME_{uuid.uuid4().hex[:8]}"
+    created = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content=f"Unique fact {marker}",
+        domain="workflow",
+        level=1,
+    )
+    fact_id = created["fact_id"]
+    rlm.call("rlm_delete_fact", fact_id=fact_id)
+
+    result = rlm.call(
+        "rlm_search_facts",
+        query=marker,
+        keyword_weight=0.9,
+        recency_weight=0.0,
+        top_k=10,
+    )
+    found_ids = [item["fact_id"] for item in result.get("results", [])]
+    assert fact_id not in found_ids
+
+
+def test_enterprise_context_include_causal(rlm, causal_seed):
+    result = rlm.call(
+        "rlm_enterprise_context",
+        query=causal_seed,
+        include_causal=True,
+    )
+    assert result.get("causal_included") is True
+    result_str = json.dumps(result, ensure_ascii=False)
+    assert causal_seed in result_str
+
+
+def test_enterprise_context_no_noise(rlm):
+    result = rlm.call("rlm_enterprise_context", query="test", include_causal=False)
+    result_str = json.dumps(result, ensure_ascii=False)
+    assert "__FINGERPRINT__" not in result_str
+    assert "Unknown project" not in result_str
+
+
+def test_record_causal_decision(rlm):
+    result = rlm.call(
+        "rlm_record_causal_decision",
+        decision="Test architecture decision",
+        reasons=["For testing purposes"],
+        alternatives=["none"],
+        consequences=["Test only, no real impact"],
+    )
+    assert result.get("decision_id") or result.get("status") == "success"
+
+
+def test_route_context_returns_facts(rlm, fact_seed):
+    result = rlm.call("rlm_route_context", query=f"PENDING tasks {fact_seed}")
+    assert result.get("facts_count", 0) > 0
+
+
+def test_discover_project_nonexistent_path(rlm):
+    result = rlm.call(
+        "rlm_discover_project",
+        project_root="/nonexistent/path/xyzzy_pytest",
+    )
+    has_warning = bool(result.get("warnings")) or result.get("status") == "error"
+    assert has_warning
+
+
+def test_no_float32_in_logs(rlm_env):
+    assert rlm_env["container_name"], "A Docker container is required for log inspection"
+    result = subprocess.run(
+        ["docker", "logs", rlm_env["container_name"]],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    logs = result.stdout + result.stderr
+    assert "not JSON serializable" not in logs
+
+
+def test_single_embedding_model_for_new_fact(rlm, rlm_env):
+    assert rlm_env["container_name"], "A Docker container is required for DB inspection"
+    created = rlm.call(
+        "rlm_add_hierarchical_fact",
+        content="Embedding model isolation test",
+        domain="workflow",
+        level=1,
+    )
+    fact_id = created["fact_id"]
+    rlm._created_ids.append(fact_id)
+
+    script = (
+        "import json, sqlite3; "
+        f"conn = sqlite3.connect({rlm_env['sqlite_path']!r}); "
+        f"print(json.dumps(conn.execute(\"SELECT DISTINCT model_name FROM embeddings_index WHERE fact_id = '{fact_id}'\").fetchall(), ensure_ascii=False))"
+    )
+    result = subprocess.run(
+        ["docker", "exec", rlm_env["container_name"], "python3", "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    models = [row[0] for row in json.loads(result.stdout.strip())] if result.stdout.strip() else []
+
+    assert models, "Expected at least one embedding row for the new fact"
+    assert len(models) == 1
+    assert models[0] == rlm_env["expected_model"]


### PR DESCRIPTION
## What changed

This PR adds an isolated pytest-based MCP regression suite for `rlm-workflow`.

- adds a dedicated `tests/pytest_suite` test suite with 19 MCP and scenario tests
- runs tests against a disposable Docker-backed RLM instance by default, so local memory/data is not polluted
- supports `RLM_TEST_URL` / `RLM_DOCKER_CONTAINER` overrides for faster local validation against an already running instance
- adds `pytest.ini` so `pytest` collects only the new suite instead of the older manual regression scripts
- adds a GitHub Actions workflow to run the suite on `push` and `pull_request`
- ignores `.pytest_cache/`

## Why

The repository already contains useful regression scripts, but they are not structured as a clean pytest suite and they can collide with real local RLM data. This change adds a repeatable, isolated path for automated verification.

## Impact

- contributors can run `pytest -v` from the repo root
- CI gets an executable regression suite for the MCP surface
- test runs no longer require reusing an existing personal `rlm-data` volume

## Validation

- `pytest tests/pytest_suite -v` on an isolated cold-start Docker container: `19 passed`
- `pytest tests/pytest_suite -v -x` against an already running local `rlm` instance via `RLM_TEST_URL`: `19 passed`
